### PR TITLE
Fix for framework-adapter-pdo.patch performance issue

### DIFF
--- a/framework-adapter-pdo.patch
+++ b/framework-adapter-pdo.patch
@@ -1,19 +1,23 @@
----
- DB/Adapter/Pdo/Mysql.php | 2 +-
- 1 file changed, 1 insertion(+), 1 deletion(-)
-
-diff --git a/DB/Adapter/Pdo/Mysql.php b/DB/Adapter/Pdo/Mysql.php
-index 66e6bb2..0b2c27b 100644
---- a/DB/Adapter/Pdo/Mysql.php
-+++ b/DB/Adapter/Pdo/Mysql.php
-@@ -2228,7 +2228,7 @@ class Mysql extends \Zend_Db_Adapter_Pdo_Mysql implements AdapterInterface
-         $ifNotExistsSql = ($ifNotExists ? 'IF NOT EXISTS' : '');
+Index: vendor/magento/framework/DB/Adapter/Pdo/Mysql.php
+IDEA additional info:
+Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
+<+>UTF-8
+===================================================================
+diff --git a/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php b/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php
+--- a/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php
++++ b/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php	(date 1661356163106)
+@@ -2229,10 +2229,12 @@
+      */
+     public function createTemporaryTableLike($temporaryTableName, $originTableName, $ifNotExists = false)
+     {
+-        $ifNotExistsSql = ($ifNotExists ? 'IF NOT EXISTS' : '');
++        $ifNotExistsSql = ($ifNotExists ? ' IF NOT EXISTS' : '');
          $temporaryTable = $this->quoteIdentifier($this->_getTableName($temporaryTableName));
          $originTable = $this->quoteIdentifier($this->_getTableName($originTableName));
 -        $sql = sprintf('CREATE TEMPORARY TABLE %s %s LIKE %s', $ifNotExistsSql, $temporaryTable, $originTable);
-+        $sql = sprintf('CREATE TEMPORARY TABLE %s %s SELECT * FROM %s', $ifNotExistsSql, $temporaryTable, $originTable);
- 
++        $originCreate = $this->fetchPairs(sprintf('SHOW CREATE TABLE %s', $originTable));
++        $sql = str_replace('CREATE TABLE', 'CREATE TEMPORARY TABLE' . $ifNotExistsSql, reset($originCreate));
++        $sql = str_replace($originTable, $temporaryTable, $sql);
+
          return $this->query($sql);
      }
--- 
-2.32.0

--- a/framework-adapter-pdo.patch
+++ b/framework-adapter-pdo.patch
@@ -5,8 +5,8 @@ Subsystem: com.intellij.openapi.diff.impl.patch.CharsetEP
 ===================================================================
 diff --git a/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php b/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php
 --- a/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php
-+++ b/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php	(date 1661356163106)
-@@ -2229,10 +2229,12 @@
++++ b/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php	(date 1661519230948)
+@@ -2229,10 +2229,14 @@
       */
      public function createTemporaryTableLike($temporaryTableName, $originTableName, $ifNotExists = false)
      {
@@ -15,8 +15,10 @@ diff --git a/vendor/magento/framework/DB/Adapter/Pdo/Mysql.php b/vendor/magento/
          $temporaryTable = $this->quoteIdentifier($this->_getTableName($temporaryTableName));
          $originTable = $this->quoteIdentifier($this->_getTableName($originTableName));
 -        $sql = sprintf('CREATE TEMPORARY TABLE %s %s LIKE %s', $ifNotExistsSql, $temporaryTable, $originTable);
-+        $originCreate = $this->fetchPairs(sprintf('SHOW CREATE TABLE %s', $originTable));
-+        $sql = str_replace('CREATE TABLE', 'CREATE TEMPORARY TABLE' . $ifNotExistsSql, reset($originCreate));
++        $originCreate = $this->fetchPairs("SHOW CREATE TABLE {$originTable}");
++        $sql = reset($originCreate);
++        $sql = preg_replace('/\/\*!50100 TABLESPACE [^\s]+ \*\//', '', $sql);
++        $sql = str_replace('CREATE TABLE', 'CREATE TEMPORARY TABLE' . $ifNotExistsSql, $sql);
 +        $sql = str_replace($originTable, $temporaryTable, $sql);
 
          return $this->query($sql);


### PR DESCRIPTION
Magento's MySQL adapter uses CREATE TEMPORARY TABLE ... LIKE command in \Magento\Framework\DB\Adapter\Pdo\Mysql::createTemporaryTableLike.

Newer versions of MySQL (8+) have problems with CREATE TEMPORARY TABLE ... LIKE, as you can read in the official documentation (https://dev.mysql.com/doc/refman/8.0/en/create-temporary-table.html):

> You cannot use CREATE TEMPORARY TABLE ... LIKE to create an empty table based on the definition of a table that resides in the mysql tablespace, InnoDB system tablespace (innodb_system), or a general tablespace.

The documentation suggests to use CREATE TEMPORARY TABLE ... SELECT * FROM ... LIMIT 0 instead, and you have used this suggestion in your patch. However, such command **IS NOT** an exact equivalent. It will create temporary table with the same fields, but will not create indexes. Without indexes performance of reindexing big amount of data is absurdly slow.

I'd like to propose different fix, that is not slowing down reindexing. I firstly use SHOW CREATE TABLE to get query for creation of source table (including indexes creation), and then I modify it with PHP: I change CREATE TABLE to CREATE TEMPORARY TABLE, I add IF NOT EXISTS if necessary, and I replace source table name with temporary table name.