### PR TITLE
Update framework-stdlib-cookie-phpcookiemanager.patch for Magento 2.4.6-p9

### DIFF
--- a/framework-stdlib-cookie-phpcookiemanager.patch
+++ b/framework-stdlib-cookie-phpcookiemanager.patch
@@ -2,18 +2,18 @@
  Stdlib/Cookie/PhpCookieManager.php | 2 +-
  1 file changed, 1 insertion(+), 1 deletion(-)
 
-diff --git a/Stdlib/Cookie/PhpCookieManager.php b/Stdlib/Cookie/PhpCookieManager.php
+diff --git a/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php b/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php
 index 64f04c6..6297111 100644
---- a/Stdlib/Cookie/PhpCookieManager.php
-+++ b/Stdlib/Cookie/PhpCookieManager.php
+--- a/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php
++++ b/vendor/magento/framework/Stdlib/Cookie/PhpCookieManager.php
 @@ -31,7 +31,7 @@ class PhpCookieManager implements CookieManagerInterface
       * RFC 2109 - Page 15
       * http://www.ietf.org/rfc/rfc6265.txt
       */
--    const MAX_NUM_COOKIES = 50;
-+    const MAX_NUM_COOKIES = 300;
-     const MAX_COOKIE_SIZE = 4096;
-     const EXPIRE_NOW_TIME = 1;
-     const EXPIRE_AT_END_OF_SESSION_TIME = 0;
+-    private const MAX_NUM_COOKIES = 50;
++    private const MAX_NUM_COOKIES = 300;
+     public const MAX_COOKIE_SIZE = 4096;
+     private const EXPIRE_NOW_TIME = 1;
+     private const EXPIRE_AT_END_OF_SESSION_TIME = 0;
 -- 
 2.32.0


### PR DESCRIPTION
Refactored to work with changes in Magento 2.4.6-p9

Not sure if this should be a new file instead, let me know your opinions! Thanks